### PR TITLE
fix(185-lambdaservicehelper-shows-unencoded-characters-in-log-file): …

### DIFF
--- a/src/db/include/awsmock/memorydb/SNSMemoryDb.h
+++ b/src/db/include/awsmock/memorydb/SNSMemoryDb.h
@@ -39,6 +39,43 @@ namespace AwsMock::Database {
     }
 
     /**
+     * Check existence of topic
+     *
+     * @param region AWS region
+     * @param name topic name
+     * @return true if topic already exists
+     * @throws DatabaseException
+     */
+    bool TopicExists(const std::string &region, const std::string &name);
+
+    /**
+     * Check existence of topic
+     *
+     * @param topicName topic ARN
+     * @return true if topic already exists
+     * @throws DatabaseException
+     */
+    bool TopicExists(const std::string &topicName);
+
+    /**
+     * Create a new topic in the SNS topic table
+     *
+     * @param topic topic entity
+     * @return created SNS topic entity
+     * @throws DatabaseException
+     */
+    Entity::SNS::Topic CreateTopic(const Entity::SNS::Topic &topic);
+
+    /**
+     * Returns a topic by primary key
+     *
+     * @param oid topic primary key
+     * @return topic entity
+     * @throws DatabaseException
+     */
+    Entity::SNS::Topic GetTopicById(const std::string &oid);
+
+    /**
      * Counts the number of topics
      *
      * @param region AWS region

--- a/src/db/src/memorydb/SNSMemoryDb.cpp
+++ b/src/db/src/memorydb/SNSMemoryDb.cpp
@@ -8,6 +8,44 @@ namespace AwsMock::Database {
 
   SNSMemoryDb::SNSMemoryDb() : _logger(Poco::Logger::get("SQSMemoryDb")) {}
 
+  bool SNSMemoryDb::TopicExists(const std::string &region, const std::string &name) {
+
+    return find_if(_topics.begin(), _topics.end(), [region, name](const std::pair<std::string, Entity::SNS::Topic> &topic) {
+      return topic.second.region == region && topic.second.topicName == name;
+    }) != _topics.end();
+
+  }
+
+  bool SNSMemoryDb::TopicExists(const std::string &name) {
+
+    return find_if(_topics.begin(), _topics.end(), [name](const std::pair<std::string, Entity::SNS::Topic> &topic) {
+      return topic.second.topicName == name;
+    }) != _topics.end();
+
+  }
+
+  Entity::SNS::Topic SNSMemoryDb::GetTopicById(const std::string &oid) {
+
+    auto it = find_if(_topics.begin(), _topics.end(), [oid](const std::pair<std::string, Entity::SNS::Topic> &queue) {
+      return queue.first == oid;
+    });
+
+    if (it != _topics.end()) {
+      it->second.oid = oid;
+      return it->second;
+    }
+    return {};
+  }
+
+  Entity::SNS::Topic SNSMemoryDb::CreateTopic(const Entity::SNS::Topic &topic) {
+
+    std::string oid = Poco::UUIDGenerator().createRandom().toString();
+    _topics[oid] = topic;
+    log_trace_stream(_logger) << "Topic created, oid: " << oid << std::endl;
+    return GetTopicById(oid);
+
+  }
+
   long SNSMemoryDb::CountTopics(const std::string &region) {
 
     long count = 0;


### PR DESCRIPTION
…add in-memory database for lambdas, sns, s3, transfer servers