### PR TITLE
fix(185-lambdaservicehelper-shows-unencoded-characters-in-log-file): …

### DIFF
--- a/src/db/src/memorydb/TransferMemoryDb.cpp
+++ b/src/db/src/memorydb/TransferMemoryDb.cpp
@@ -18,7 +18,7 @@ namespace AwsMock::Database {
 
   bool TransferMemoryDb::TransferExists(const Entity::Transfer::Transfer &transfer) {
 
-    TransferExists(transfer.region, transfer.serverId);
+    return TransferExists(transfer.region, transfer.serverId);
 
   }
 

--- a/src/service/include/awsmock/service/LambdaMonitoring.h
+++ b/src/service/include/awsmock/service/LambdaMonitoring.h
@@ -25,7 +25,6 @@
 #include <awsmock/core/Configuration.h>
 #include <awsmock/core/CryptoUtils.h>
 #include <awsmock/core/DirUtils.h>
-#include <awsmock/core/DirectoryWatcher.h>
 #include <awsmock/core/FileUtils.h>
 #include <awsmock/core/HttpUtils.h>
 #include <awsmock/core/LogStream.h>

--- a/src/service/include/awsmock/service/S3Monitoring.h
+++ b/src/service/include/awsmock/service/S3Monitoring.h
@@ -25,7 +25,6 @@
 #include <awsmock/core/Configuration.h>
 #include <awsmock/core/CryptoUtils.h>
 #include <awsmock/core/DirUtils.h>
-#include <awsmock/core/DirectoryWatcher.h>
 #include <awsmock/core/FileUtils.h>
 #include <awsmock/core/HttpUtils.h>
 #include <awsmock/core/LogStream.h>

--- a/src/service/include/awsmock/service/S3Service.h
+++ b/src/service/include/awsmock/service/S3Service.h
@@ -15,7 +15,6 @@
 
 // AwsMock includes
 #include "awsmock/core/CryptoUtils.h"
-#include "awsmock/core/DirectoryWatcher.h"
 #include "awsmock/core/LogStream.h"
 #include "awsmock/core/ServiceException.h"
 #include "awsmock/repository/S3Database.h"

--- a/src/service/include/awsmock/service/SNSMonitoring.h
+++ b/src/service/include/awsmock/service/SNSMonitoring.h
@@ -25,7 +25,6 @@
 #include <awsmock/core/Configuration.h>
 #include <awsmock/core/CryptoUtils.h>
 #include <awsmock/core/DirUtils.h>
-#include <awsmock/core/DirectoryWatcher.h>
 #include <awsmock/core/FileUtils.h>
 #include <awsmock/core/HttpUtils.h>
 #include <awsmock/core/LogStream.h>

--- a/src/service/include/awsmock/service/SQSMonitoring.h
+++ b/src/service/include/awsmock/service/SQSMonitoring.h
@@ -25,7 +25,6 @@
 #include <awsmock/core/Configuration.h>
 #include <awsmock/core/CryptoUtils.h>
 #include <awsmock/core/DirUtils.h>
-#include <awsmock/core/DirectoryWatcher.h>
 #include <awsmock/core/FileUtils.h>
 #include <awsmock/core/HttpUtils.h>
 #include <awsmock/core/LogStream.h>


### PR DESCRIPTION
…fix unit tests