### PR TITLE
fix(185-lambdaservicehelper-shows-unencoded-characters-in-log-file): …

### DIFF
--- a/src/dto/tst/main.cpp
+++ b/src/dto/tst/main.cpp
@@ -8,9 +8,6 @@
 // GTest includes
 #include <gtest/gtest.h>
 
-// Poco includes
-#include <Poco/ThreadPool.h>
-
 // Test includes
 #include <awsmock/core/TestUtils.h>
 #include <awsmock/utils/TestUtils.h>
@@ -21,8 +18,6 @@ public:
   // Initialise a test configuration.
   void SetUp() override {
     AwsMock::Core::TestUtils::CreateTestConfigurationFile();
-    AwsMock::Database::TestUtils::CreateServices();
-    Poco::ThreadPool::defaultPool().addCapacity(256);
   }
 };
 


### PR DESCRIPTION
…Cleanup transfer DTOs